### PR TITLE
Added shape system.

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -25,6 +25,9 @@
       <SelectionState runConfigName="TypographyTest">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="ShapesTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/core/ui/src/androidTest/java/com/stoyanvuchev/weather/core/ui/theme/shape/ShapesTest.kt
+++ b/core/ui/src/androidTest/java/com/stoyanvuchev/weather/core/ui/theme/shape/ShapesTest.kt
@@ -1,0 +1,56 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.weather.core.ui.theme.shape
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ShapesTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun localShapes_provides_shapesValues() {
+        composeTestRule.setContent {
+            val shapes = remember { Shapes() }
+            CompositionLocalProvider(LocalShapes provides shapes) {
+                assertThat(LocalShapes.current).isEqualTo(shapes)
+                assertThat(LocalShapes.current.large).isEqualTo(shapes.large)
+                assertThat(LocalShapes.current.medium).isEqualTo(shapes.medium)
+                assertThat(LocalShapes.current.small).isEqualTo(shapes.small)
+            }
+        }
+    }
+
+}

--- a/core/ui/src/main/java/com/stoyanvuchev/weather/core/ui/theme/shape/ShapeData.kt
+++ b/core/ui/src/main/java/com/stoyanvuchev/weather/core/ui/theme/shape/ShapeData.kt
@@ -1,0 +1,38 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.weather.core.ui.theme.shape
+
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
+
+@Stable
+data class ShapeData(
+    val shape: Shape,
+    val topStartRadius: Dp,
+    val topEndRadius: Dp,
+    val bottomStartRadius: Dp,
+    val bottomEndRadius: Dp
+)

--- a/core/ui/src/main/java/com/stoyanvuchev/weather/core/ui/theme/shape/ShapeTokens.kt
+++ b/core/ui/src/main/java/com/stoyanvuchev/weather/core/ui/theme/shape/ShapeTokens.kt
@@ -1,0 +1,61 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.weather.core.ui.theme.shape
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.unit.dp
+import sv.lib.squircleshape.SquircleShape
+
+@Immutable
+object ShapeTokens {
+
+    val large: ShapeData
+        get() = ShapeData(
+            shape = SquircleShape(percent = 100, smoothing = 10),
+            topStartRadius = 999.dp,
+            topEndRadius = 999.dp,
+            bottomStartRadius = 999.dp,
+            bottomEndRadius = 999.dp
+        )
+
+    val medium: ShapeData
+        get() = ShapeData(
+            shape = SquircleShape(radius = 20.dp, smoothing = 50),
+            topStartRadius = 20.dp,
+            topEndRadius = 20.dp,
+            bottomStartRadius = 20.dp,
+            bottomEndRadius = 20.dp
+        )
+
+    val small: ShapeData
+        get() = ShapeData(
+            shape = SquircleShape(radius = 10.dp, smoothing = 50),
+            topStartRadius = 10.dp,
+            topEndRadius = 10.dp,
+            bottomStartRadius = 10.dp,
+            bottomEndRadius = 10.dp
+        )
+
+}

--- a/core/ui/src/main/java/com/stoyanvuchev/weather/core/ui/theme/shape/Shapes.kt
+++ b/core/ui/src/main/java/com/stoyanvuchev/weather/core/ui/theme/shape/Shapes.kt
@@ -1,0 +1,37 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.weather.core.ui.theme.shape
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.staticCompositionLocalOf
+
+@Stable
+data class Shapes(
+    val large: ShapeData = ShapeTokens.large,
+    val medium: ShapeData = ShapeTokens.medium,
+    val small: ShapeData = ShapeTokens.small
+)
+
+val LocalShapes = staticCompositionLocalOf { Shapes() }


### PR DESCRIPTION
This commit introduces a custom shape system based on squircles to the `:core:ui` module. It defines a set of shapes (large, medium, small) and makes them available throughout the Compose UI via a `CompositionLocal`.

### Shape System (`:core:ui`)
- **`ShapeData`**: A new data class to hold a `Shape` along with its corner radii (`topStartRadius`, `topEndRadius`, etc.).
- **`ShapeTokens`**: An object that defines the concrete shape values for `large`, `medium`, and `small` categories using `SquircleShape` from the `sv.lib.squircleshape` library.
  - `large`: A fully rounded (pill) shape.
  - `medium`: A squircle with a 20.dp radius.
  - `small`: A squircle with a 10.dp radius.
- **`Shapes`**: A data class that holds the defined `large`, `medium`, and `small` `ShapeData` tokens.
- **`LocalShapes`**: A `staticCompositionLocalOf` that provides the `Shapes` instance to the component hierarchy.
- **Testing**: Adds an instrumented test (`ShapesTest`) to verify that the `LocalShapes` correctly provides the defined shape values.