### PR TITLE
Refactored theme accessors and added theme wrapper.

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -13,12 +13,6 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
-      <SelectionState runConfigName="LocalDatabaseTest">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="WeatherRepositoryImplTest">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
       <SelectionState runConfigName="ColorPaletteTest">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
@@ -26,6 +20,12 @@
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
       <SelectionState runConfigName="ShapesTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="ThemeTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="ThemeWrapperTest">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
     </selectionStates>

--- a/core/ui/src/androidTest/java/com/stoyanvuchev/weather/core/ui/theme/ThemeTest.kt
+++ b/core/ui/src/androidTest/java/com/stoyanvuchev/weather/core/ui/theme/ThemeTest.kt
@@ -1,0 +1,106 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.weather.core.ui.theme
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.stoyanvuchev.weather.core.ui.theme.color.LocalColorPalette
+import com.stoyanvuchev.weather.core.ui.theme.color.toColorPalette
+import com.stoyanvuchev.weather.core.ui.theme.shape.LocalShapes
+import com.stoyanvuchev.weather.core.ui.theme.shape.Shapes
+import com.stoyanvuchev.weather.core.ui.theme.typography.LocalTypography
+import com.stoyanvuchev.weather.core.ui.theme.typography.Typography
+import com.stoyanvuchev.weather.domain.other.WeatherCondition
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ThemeTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun theme_provides_colors_typography_and_shapes() {
+        composeTestRule.setContent {
+
+            val colorPalette = remember { WeatherCondition.SUNNY.toColorPalette(false) }
+            val typography = remember { Typography() }
+            val shapes = remember { Shapes() }
+
+            CompositionLocalProvider(
+                LocalColorPalette provides colorPalette,
+                LocalTypography provides typography,
+                LocalShapes provides shapes
+            ) {
+
+                // Colors
+
+                assertThat(Theme.colorPalette).isEqualTo(colorPalette)
+                assertThat(Theme.colorPalette.primary).isEqualTo(colorPalette.primary)
+                assertThat(Theme.colorPalette.onPrimary).isEqualTo(colorPalette.onPrimary)
+                assertThat(Theme.colorPalette.secondary).isEqualTo(colorPalette.secondary)
+                assertThat(Theme.colorPalette.onSecondary).isEqualTo(colorPalette.onSecondary)
+                assertThat(Theme.colorPalette.surfaceLow).isEqualTo(colorPalette.surfaceLow)
+                assertThat(Theme.colorPalette.onSurfaceLow).isEqualTo(colorPalette.onSurfaceLow)
+                assertThat(Theme.colorPalette.surfaceMedium).isEqualTo(colorPalette.surfaceMedium)
+                assertThat(Theme.colorPalette.onSurfaceMedium).isEqualTo(colorPalette.onSurfaceMedium)
+                assertThat(Theme.colorPalette.surfaceHigh).isEqualTo(colorPalette.surfaceHigh)
+                assertThat(Theme.colorPalette.onSurfaceHigh).isEqualTo(colorPalette.onSurfaceHigh)
+                assertThat(Theme.colorPalette.error).isEqualTo(colorPalette.error)
+                assertThat(Theme.colorPalette.conditionPrimary).isEqualTo(colorPalette.conditionPrimary)
+                assertThat(Theme.colorPalette.conditionSecondary).isEqualTo(colorPalette.conditionSecondary)
+
+                // Typography
+
+                assertThat(Theme.typography).isEqualTo(typography)
+                assertThat(Theme.typography.displayLarge).isEqualTo(typography.displayLarge)
+                assertThat(Theme.typography.titleLarge).isEqualTo(typography.titleLarge)
+                assertThat(Theme.typography.titleSmall).isEqualTo(typography.titleSmall)
+                assertThat(Theme.typography.bodyLarge).isEqualTo(typography.bodyLarge)
+                assertThat(Theme.typography.bodyMedium).isEqualTo(typography.bodyMedium)
+                assertThat(Theme.typography.bodySmall).isEqualTo(typography.bodySmall)
+                assertThat(Theme.typography.labelLarge).isEqualTo(typography.labelLarge)
+                assertThat(Theme.typography.labelMedium).isEqualTo(typography.labelMedium)
+                assertThat(Theme.typography.labelSmall).isEqualTo(typography.labelSmall)
+
+                // Shapes
+
+                assertThat(Theme.shapes).isEqualTo(shapes)
+                assertThat(Theme.shapes.large).isEqualTo(shapes.large)
+                assertThat(Theme.shapes.medium).isEqualTo(shapes.medium)
+                assertThat(Theme.shapes.small).isEqualTo(shapes.small)
+
+            }
+
+        }
+    }
+
+}

--- a/core/ui/src/androidTest/java/com/stoyanvuchev/weather/core/ui/theme/ThemeWrapperTest.kt
+++ b/core/ui/src/androidTest/java/com/stoyanvuchev/weather/core/ui/theme/ThemeWrapperTest.kt
@@ -1,0 +1,102 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.weather.core.ui.theme
+
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.stoyanvuchev.weather.core.ui.theme.color.toColorPalette
+import com.stoyanvuchev.weather.core.ui.theme.shape.Shapes
+import com.stoyanvuchev.weather.core.ui.theme.typography.Typography
+import com.stoyanvuchev.weather.domain.other.WeatherCondition
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ThemeWrapperTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun themeWrapper_provides_theme() {
+        composeTestRule.setContent {
+
+            val colorPalette = remember { WeatherCondition.SUNNY.toColorPalette(true) }
+            val typography = remember { Typography() }
+            val shapes = remember { Shapes() }
+
+            ThemeWrapper(
+                colorPalette = colorPalette,
+                typography = typography,
+                shapes = shapes
+            ) {
+
+                // Colors
+
+                assertThat(Theme.colorPalette).isEqualTo(colorPalette)
+                assertThat(Theme.colorPalette.primary).isEqualTo(colorPalette.primary)
+                assertThat(Theme.colorPalette.onPrimary).isEqualTo(colorPalette.onPrimary)
+                assertThat(Theme.colorPalette.secondary).isEqualTo(colorPalette.secondary)
+                assertThat(Theme.colorPalette.onSecondary).isEqualTo(colorPalette.onSecondary)
+                assertThat(Theme.colorPalette.surfaceLow).isEqualTo(colorPalette.surfaceLow)
+                assertThat(Theme.colorPalette.onSurfaceLow).isEqualTo(colorPalette.onSurfaceLow)
+                assertThat(Theme.colorPalette.surfaceMedium).isEqualTo(colorPalette.surfaceMedium)
+                assertThat(Theme.colorPalette.onSurfaceMedium).isEqualTo(colorPalette.onSurfaceMedium)
+                assertThat(Theme.colorPalette.surfaceHigh).isEqualTo(colorPalette.surfaceHigh)
+                assertThat(Theme.colorPalette.onSurfaceHigh).isEqualTo(colorPalette.onSurfaceHigh)
+                assertThat(Theme.colorPalette.error).isEqualTo(colorPalette.error)
+                assertThat(Theme.colorPalette.conditionPrimary).isEqualTo(colorPalette.conditionPrimary)
+                assertThat(Theme.colorPalette.conditionSecondary).isEqualTo(colorPalette.conditionSecondary)
+
+                // Typography
+
+                assertThat(Theme.typography).isEqualTo(typography)
+                assertThat(Theme.typography.displayLarge).isEqualTo(typography.displayLarge)
+                assertThat(Theme.typography.titleLarge).isEqualTo(typography.titleLarge)
+                assertThat(Theme.typography.titleSmall).isEqualTo(typography.titleSmall)
+                assertThat(Theme.typography.bodyLarge).isEqualTo(typography.bodyLarge)
+                assertThat(Theme.typography.bodyMedium).isEqualTo(typography.bodyMedium)
+                assertThat(Theme.typography.bodySmall).isEqualTo(typography.bodySmall)
+                assertThat(Theme.typography.labelLarge).isEqualTo(typography.labelLarge)
+                assertThat(Theme.typography.labelMedium).isEqualTo(typography.labelMedium)
+                assertThat(Theme.typography.labelSmall).isEqualTo(typography.labelSmall)
+
+                // Shapes
+
+                assertThat(Theme.shapes).isEqualTo(shapes)
+                assertThat(Theme.shapes.large).isEqualTo(shapes.large)
+                assertThat(Theme.shapes.medium).isEqualTo(shapes.medium)
+                assertThat(Theme.shapes.small).isEqualTo(shapes.small)
+
+            }
+
+        }
+    }
+
+}

--- a/core/ui/src/androidTest/java/com/stoyanvuchev/weather/core/ui/theme/color/ColorPaletteTest.kt
+++ b/core/ui/src/androidTest/java/com/stoyanvuchev/weather/core/ui/theme/color/ColorPaletteTest.kt
@@ -79,6 +79,23 @@ class ColorPaletteTest {
         }
     }
 
+    @Test
+    fun localColor_match_color() {
+        composeTestRule.setContent {
+
+            val color = remember {
+                WeatherCondition.SUNNY
+                    .toColorPalette(false)
+                    .onSurfaceLow
+            }
+
+            CompositionLocalProvider(LocalColor provides color) {
+                assertThat(LocalColor.current).isEqualTo(color)
+            }
+
+        }
+    }
+
     private fun assertPaletteEquals(actual: ColorPalette, expected: ColorPalette) {
         assertThat(actual.primary).isEqualTo(expected.primary)
         assertThat(actual.onPrimary).isEqualTo(expected.onPrimary)

--- a/core/ui/src/androidTest/java/com/stoyanvuchev/weather/core/ui/theme/typography/TypographyTest.kt
+++ b/core/ui/src/androidTest/java/com/stoyanvuchev/weather/core/ui/theme/typography/TypographyTest.kt
@@ -59,4 +59,14 @@ class TypographyTest {
         }
     }
 
+    @Test
+    fun localTextStyle_matches_textStyle() {
+        composeTestRule.setContent {
+            val textStyle = remember { TypographyTokens.bodyMedium }
+            CompositionLocalProvider(LocalTextStyle provides textStyle) {
+                assertThat(LocalTextStyle.current).isEqualTo(textStyle)
+            }
+        }
+    }
+
 }

--- a/core/ui/src/main/java/com/stoyanvuchev/weather/core/ui/theme/Theme.kt
+++ b/core/ui/src/main/java/com/stoyanvuchev/weather/core/ui/theme/Theme.kt
@@ -22,24 +22,34 @@
  * SOFTWARE.
  */
 
-package com.stoyanvuchev.weather.core.ui.theme.typography
+package com.stoyanvuchev.weather.core.ui.theme
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.compose.ui.text.TextStyle
+import com.stoyanvuchev.weather.core.ui.theme.color.ColorPalette
+import com.stoyanvuchev.weather.core.ui.theme.color.LocalColorPalette
+import com.stoyanvuchev.weather.core.ui.theme.shape.LocalShapes
+import com.stoyanvuchev.weather.core.ui.theme.shape.Shapes
+import com.stoyanvuchev.weather.core.ui.theme.typography.LocalTypography
+import com.stoyanvuchev.weather.core.ui.theme.typography.Typography
 
 @Stable
-data class Typography(
-    val displayLarge: TextStyle = TypographyTokens.displayLarge,
-    val titleLarge: TextStyle = TypographyTokens.titleLarge,
-    val titleSmall: TextStyle = TypographyTokens.titleSmall,
-    val bodyLarge: TextStyle = TypographyTokens.bodyLarge,
-    val bodyMedium: TextStyle = TypographyTokens.bodyMedium,
-    val bodySmall: TextStyle = TypographyTokens.bodySmall,
-    val labelLarge: TextStyle = TypographyTokens.labelLarge,
-    val labelMedium: TextStyle = TypographyTokens.labelMedium,
-    val labelSmall: TextStyle = TypographyTokens.labelSmall
-)
+object Theme {
 
-val LocalTypography = staticCompositionLocalOf { Typography() }
-val LocalTextStyle = staticCompositionLocalOf { TypographyTokens.bodyMedium }
+    val colorPalette: ColorPalette
+        @ReadOnlyComposable
+        @Composable
+        get() = LocalColorPalette.current
+
+    val typography: Typography
+        @ReadOnlyComposable
+        @Composable
+        get() = LocalTypography.current
+
+    val shapes: Shapes
+        @ReadOnlyComposable
+        @Composable
+        get() = LocalShapes.current
+
+}

--- a/core/ui/src/main/java/com/stoyanvuchev/weather/core/ui/theme/ThemeWrapper.kt
+++ b/core/ui/src/main/java/com/stoyanvuchev/weather/core/ui/theme/ThemeWrapper.kt
@@ -1,0 +1,59 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.weather.core.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import com.stoyanvuchev.weather.core.ui.theme.color.ColorPalette
+import com.stoyanvuchev.weather.core.ui.theme.color.LocalColorPalette
+import com.stoyanvuchev.weather.core.ui.theme.color.asAnimatedColorPalette
+import com.stoyanvuchev.weather.core.ui.theme.shape.LocalShapes
+import com.stoyanvuchev.weather.core.ui.theme.shape.Shapes
+import com.stoyanvuchev.weather.core.ui.theme.typography.LocalTypography
+import com.stoyanvuchev.weather.core.ui.theme.typography.Typography
+
+@Composable
+fun ThemeWrapper(
+    colorPalette: ColorPalette,
+    typography: Typography,
+    shapes: Shapes,
+    content: @Composable () -> Unit
+) {
+
+    val animatedColorPalette by rememberUpdatedState(
+        colorPalette.asAnimatedColorPalette()
+    )
+
+    CompositionLocalProvider(
+        LocalColorPalette provides animatedColorPalette,
+        LocalTypography provides typography,
+        LocalTypography provides typography,
+        LocalShapes provides shapes,
+        content = content
+    )
+
+}

--- a/core/ui/src/main/java/com/stoyanvuchev/weather/core/ui/theme/color/ColorPalette.kt
+++ b/core/ui/src/main/java/com/stoyanvuchev/weather/core/ui/theme/color/ColorPalette.kt
@@ -209,3 +209,11 @@ val LocalColorPalette = compositionLocalOf {
         lightTokens = LightSunnyDayColorPaletteTokens
     )
 }
+
+val LocalColor = compositionLocalOf {
+    colorPalette(
+        darkTheme = true,
+        darkTokens = DarkSunnyDayColorPaletteTokens,
+        lightTokens = LightSunnyDayColorPaletteTokens
+    ).onSurfaceLow
+}


### PR DESCRIPTION
This commit introduces a centralized `Theme` object and a `ThemeWrapper` composable to streamline access to theme properties like colors, typography, and shapes.

### Key Changes
- **`Theme` Object**:
    - Added a `Theme` object that provides convenient, read-only Composable accessors for `colorPalette`, `typography`, and `shapes` by retrieving them from their respective `CompositionLocal` providers (`LocalColorPalette`, `LocalTypography`, `LocalShapes`).

- **`ThemeWrapper` Composable**:
    - Created a new `ThemeWrapper` composable that sets up the `CompositionLocalProvider` for the entire theme.
    - It takes `ColorPalette`, `Typography`, and `Shapes` as arguments and provides them down the Composable tree.
    - It automatically applies animations to `ColorPalette` changes using `asAnimatedColorPalette()`.

- **New `CompositionLocal`s**:
    - Introduced `LocalColor` and `LocalTextStyle` to provide default fallbacks for a single color and text style, respectively.

### Testing
- Added instrumented tests (`ThemeTest`, `ThemeWrapperTest`) to verify that the `Theme` object and `ThemeWrapper` correctly provide the expected color, typography, and shape values.
- Expanded existing tests to validate the new `LocalColor` and `LocalTextStyle` providers.