### PR TITLE
Refactored theme wrapper to support haze effect.

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -19,13 +19,13 @@
       <SelectionState runConfigName="TypographyTest">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
-      <SelectionState runConfigName="ShapesTest">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
       <SelectionState runConfigName="ThemeTest">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
       <SelectionState runConfigName="ThemeWrapperTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="LocalHazeStateTest">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
     </selectionStates>

--- a/core/ui/src/androidTest/java/com/stoyanvuchev/weather/core/ui/theme/haze/LocalHazeStateTest.kt
+++ b/core/ui/src/androidTest/java/com/stoyanvuchev/weather/core/ui/theme/haze/LocalHazeStateTest.kt
@@ -1,0 +1,53 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.weather.core.ui.theme.haze
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import dev.chrisbanes.haze.rememberHazeState
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LocalHazeStateTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun localHazeState_provides_hazeState() {
+        composeTestRule.setContent {
+            val hazeState = rememberHazeState()
+            CompositionLocalProvider(LocalHazeState provides hazeState) {
+                assertThat(LocalHazeState.current).isEqualTo(hazeState)
+            }
+        }
+    }
+
+}

--- a/core/ui/src/main/java/com/stoyanvuchev/weather/core/ui/theme/ThemeWrapper.kt
+++ b/core/ui/src/main/java/com/stoyanvuchev/weather/core/ui/theme/ThemeWrapper.kt
@@ -29,12 +29,15 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import com.stoyanvuchev.weather.core.ui.theme.color.ColorPalette
+import com.stoyanvuchev.weather.core.ui.theme.color.LocalColor
 import com.stoyanvuchev.weather.core.ui.theme.color.LocalColorPalette
 import com.stoyanvuchev.weather.core.ui.theme.color.asAnimatedColorPalette
+import com.stoyanvuchev.weather.core.ui.theme.haze.LocalHazeState
 import com.stoyanvuchev.weather.core.ui.theme.shape.LocalShapes
 import com.stoyanvuchev.weather.core.ui.theme.shape.Shapes
 import com.stoyanvuchev.weather.core.ui.theme.typography.LocalTypography
 import com.stoyanvuchev.weather.core.ui.theme.typography.Typography
+import dev.chrisbanes.haze.rememberHazeState
 
 @Composable
 fun ThemeWrapper(
@@ -44,15 +47,17 @@ fun ThemeWrapper(
     content: @Composable () -> Unit
 ) {
 
+    val hazeState = rememberHazeState()
     val animatedColorPalette by rememberUpdatedState(
         colorPalette.asAnimatedColorPalette()
     )
 
     CompositionLocalProvider(
         LocalColorPalette provides animatedColorPalette,
-        LocalTypography provides typography,
+        LocalColor provides animatedColorPalette.onSurfaceLow,
         LocalTypography provides typography,
         LocalShapes provides shapes,
+        LocalHazeState provides hazeState,
         content = content
     )
 

--- a/core/ui/src/main/java/com/stoyanvuchev/weather/core/ui/theme/haze/LocalHazeState.kt
+++ b/core/ui/src/main/java/com/stoyanvuchev/weather/core/ui/theme/haze/LocalHazeState.kt
@@ -1,0 +1,30 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.weather.core.ui.theme.haze
+
+import androidx.compose.runtime.compositionLocalOf
+import dev.chrisbanes.haze.HazeState
+
+val LocalHazeState = compositionLocalOf { HazeState() }


### PR DESCRIPTION
This commit introduces `LocalHazeState` to integrate the `Haze` library for creating blurred, glassmorphism UI effects.

### Core UI Module (`:core:ui`)
- **`LocalHazeState`**:
  - Adds a new `CompositionLocal`, `LocalHazeState`, to provide a `HazeState` instance throughout the Composable hierarchy.
- **`ThemeWrapper` Refactor**:
  - The `ThemeWrapper` now creates and provides a `HazeState` using `rememberHazeState()` and the new `LocalHazeState`.
- **`LocalColor`**:
  - Introduces `LocalColor`, a new `CompositionLocal`, which is provided with the `onSurfaceLow` color from the current color palette.
- **Testing**:
  - Adds an instrumented test (`LocalHazeStateTest`) to verify that `LocalHazeState` correctly provides the `HazeState` instance within the composition.