### PR TITLE
Added reusable Icon composable.

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -16,9 +16,6 @@
       <SelectionState runConfigName="ColorPaletteTest">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
-      <SelectionState runConfigName="TypographyTest">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
       <SelectionState runConfigName="ThemeWrapperTest">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
@@ -26,6 +23,9 @@
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
       <SelectionState runConfigName="TextTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="IconTest">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
     </selectionStates>

--- a/app/src/main/java/com/stoyanvuchev/weather/MainActivity.kt
+++ b/app/src/main/java/com/stoyanvuchev/weather/MainActivity.kt
@@ -28,13 +28,17 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.stoyanvuchev.weather.core.ui.components.icon.Icon
 import com.stoyanvuchev.weather.core.ui.components.text.Text
 import com.stoyanvuchev.weather.core.ui.theme.Theme
 import com.stoyanvuchev.weather.ui.theme.WeatherTheme
@@ -55,12 +59,21 @@ class MainActivity : ComponentActivity() {
                     contentColor = Theme.colorPalette.onSurfaceLow
                 ) { innerPadding ->
 
-                    Box(
+                    Column(
                         modifier = Modifier
                             .fillMaxSize()
                             .padding(innerPadding),
-                        contentAlignment = Alignment.Center
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(
+                            space = 24.dp,
+                            alignment = Alignment.CenterVertically
+                        )
                     ) {
+
+                        Icon(
+                            painter = painterResource(R.drawable.cloud),
+                            contentDescription = null
+                        )
 
                         Text(
                             text = "Hello, ${stringResource(R.string.app_name)}!"

--- a/app/src/main/res/drawable/cloud.xml
+++ b/app/src/main/res/drawable/cloud.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="128"
+    android:viewportHeight="128">
+
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M39,53.31C25.19,53.31 14,64.55 14,78.43C14,92.3 25.19,103.54 39,103.54H89C102.81,103.54 114,92.3 114,78.43C114,64.55 102.81,53.31 89,53.31L89,49.12C89,35.25 77.81,24 64,24C50.19,24 39,35.25 39,49.12L39,53.31ZM39,53.31C49.09,53.31 57.78,59.31 61.73,67.96"
+        android:strokeWidth="6"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+
+</vector>

--- a/core/ui/src/androidTest/java/com/stoyanvuchev/weather/core/ui/components/icon/IconTest.kt
+++ b/core/ui/src/androidTest/java/com/stoyanvuchev/weather/core/ui/components/icon/IconTest.kt
@@ -1,0 +1,143 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.weather.core.ui.components.icon
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.stoyanvuchev.weather.core.ui.theme.ThemeWrapper
+import com.stoyanvuchev.weather.core.ui.theme.color.toColorPalette
+import com.stoyanvuchev.weather.domain.other.WeatherCondition
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class IconTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun icon_displaysPainter() {
+
+        composeTestRule.setContent {
+            WithThemeWrapper {
+                Icon(
+                    painter = ColorPainter(Color.Red),
+                    contentDescription = "Red icon"
+                )
+            }
+        }
+
+        composeTestRule
+            .onNode(hasContentDescription("Red icon"))
+            .assertIsDisplayed()
+            .assertIsEnabled()
+
+    }
+
+    @Test
+    fun icon_setsCorrectSemanticsRole() {
+
+        composeTestRule.setContent {
+            WithThemeWrapper {
+                Icon(
+                    painter = ColorPainter(Color.Green),
+                    contentDescription = "Green icon"
+                )
+            }
+        }
+
+        composeTestRule
+            .onNode(hasRole(Role.Image) and hasContentDescription("Green icon"))
+            .assertExists()
+
+    }
+
+    @Test
+    fun icon_withoutContentDescription_hasNoSemantics() {
+
+        composeTestRule.setContent {
+            WithThemeWrapper {
+                Icon(
+                    painter = ColorPainter(Color.Blue),
+                    contentDescription = null
+                )
+            }
+        }
+
+        composeTestRule
+            .onNode(hasRole(Role.Image))
+            .assertDoesNotExist()
+
+    }
+
+    @Test
+    fun icon_appliesTintWithoutCrashing() {
+
+        composeTestRule.setContent {
+            WithThemeWrapper {
+                Icon(
+                    painter = ColorPainter(Color.Black),
+                    contentDescription = "Tinted",
+                    tint = Color.Magenta
+                )
+            }
+        }
+
+        // Can’t directly assert tint, but ensures it composes safely.
+        composeTestRule.onNode(hasContentDescription("Tinted")).assertExists()
+
+    }
+
+    @Composable
+    private fun WithThemeWrapper(
+        content: @Composable () -> Unit
+    ) = ThemeWrapper(
+        colorPalette = remember {
+            WeatherCondition.SUNNY.toColorPalette(darkTheme = false)
+        },
+        content = content
+    )
+
+    private fun hasRole(
+        expectedRole: Role
+    ): SemanticsMatcher = SemanticsMatcher.expectValue(
+        SemanticsProperties.Role,
+        expectedRole
+    )
+
+
+}

--- a/core/ui/src/main/java/com/stoyanvuchev/weather/core/ui/components/icon/Icon.kt
+++ b/core/ui/src/main/java/com/stoyanvuchev/weather/core/ui/components/icon/Icon.kt
@@ -1,0 +1,89 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Stoyan Vuchev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.stoyanvuchev.weather.core.ui.components.icon
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.paint
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.toolingGraphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.stoyanvuchev.weather.core.ui.theme.color.LocalColor
+
+@Composable
+fun Icon(
+    painter: Painter,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    tint: Color = LocalColor.current,
+) {
+
+    val colorFilter = remember(tint) { ColorFilter.tint(tint) }
+    val semantics = remember(contentDescription) {
+        if (contentDescription != null) Modifier.semantics {
+            this.contentDescription = contentDescription
+            this.role = Role.Image
+        } else Modifier
+    }
+
+    Box(
+        modifier = modifier
+            .toolingGraphicsLayer()
+            .defaultSizeFor(painter)
+            .paint(
+                painter,
+                colorFilter = colorFilter,
+                contentScale = ContentScale.Fit
+            )
+            .then(semantics)
+    )
+
+}
+
+@Stable
+private fun Modifier.defaultSizeFor(
+    painter: Painter
+) = this.then(
+    if (
+        painter.intrinsicSize == Size.Unspecified
+        || painter.intrinsicSize.isInfinite()
+    ) DefaultIconSizeModifier else Modifier
+)
+
+@Stable
+private fun Size.isInfinite() = width.isInfinite() && height.isInfinite()
+private val DefaultIconSizeModifier = Modifier.size(24.dp)


### PR DESCRIPTION
This commit introduces a reusable `Icon` composable in the `:core:ui` module, designed to replace the standard `androidx.compose.material3.Icon`. The new component provides better semantics handling and default sizing.

### Icon Composable (`:core:ui`)
- **`Icon.kt`**:
    - Defines a new `@Composable fun Icon` that accepts a `painter`, `contentDescription`, `modifier`, and `tint`.
    - It uses a `Box` with the `paint` modifier for rendering, which offers more control than the standard `Icon`.
    - Automatically applies a default size of `24.dp` if the painter has an unspecified or infinite intrinsic size.
    - Improves accessibility by applying semantics (`contentDescription` and `Role.Image`) only when a `contentDescription` is provided. If `null`, no semantics are added, making it purely decorative.
    - The `tint` defaults to `LocalColor.current`, ensuring it adapts to the surrounding theme.

### Testing (`:core:ui`)
- **`IconTest.kt`**:
    - Adds instrumented tests to verify the behavior of the new `Icon` composable.
    - Tests include:
        - Verifying that the icon is displayed correctly.
        - Ensuring the correct semantics (`Role.Image`) are set when a `contentDescription` is provided. - Confirming that no semantics are applied when `contentDescription` is `null`. - Checking that applying a `tint` does not cause crashes.